### PR TITLE
buildctl: Add configured TLS certificate to trust store when making calls to registry auth

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -105,6 +105,10 @@ var buildCommand = cli.Command{
 			Name:  "ref-file",
 			Usage: "Write build ref to a file",
 		},
+		cli.StringSliceFlag{
+			Name:  "registry-auth-tlscontext",
+			Usage: "Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt",
+		},
 	},
 }
 
@@ -158,7 +162,11 @@ func buildAction(clicontext *cli.Context) error {
 	}
 
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
-	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig)}
+	tlsConfigs, err := build.ParseRegistryAuthTLSContext(clicontext.StringSlice("registry-auth-tlscontext"))
+	if err != nil {
+		return err
+	}
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig, tlsConfigs)}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {
 		configs, err := build.ParseSSH(ssh)

--- a/cmd/buildctl/build/registryauthtlscontext.go
+++ b/cmd/buildctl/build/registryauthtlscontext.go
@@ -1,0 +1,84 @@
+package build
+
+import (
+	"encoding/csv"
+	"strings"
+
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/pkg/errors"
+)
+
+type authTLSContextEntry struct {
+	Host string
+	CA   string
+	Cert string
+	Key  string
+}
+
+func parseRegistryAuthTLSContextCSV(s string) (authTLSContextEntry, error) {
+	authTLSContext := authTLSContextEntry{}
+	csvReader := csv.NewReader(strings.NewReader(s))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return authTLSContext, err
+	}
+	for _, field := range fields {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			return authTLSContext, errors.Errorf("invalid value %s", field)
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "host":
+			authTLSContext.Host = value
+		case "ca":
+			authTLSContext.CA = value
+		case "cert":
+			authTLSContext.Cert = value
+		case "key":
+			authTLSContext.Key = value
+		}
+	}
+	if authTLSContext.Host == "" {
+		return authTLSContext, errors.New("--registry-auth-tlscontext requires host=<host>")
+	}
+	if authTLSContext.CA == "" {
+		if authTLSContext.Cert == "" || authTLSContext.Key == "" {
+			return authTLSContext, errors.New("--registry-auth-tlscontext requires ca=<ca> or cert=<cert>,key=<key>")
+		}
+	} else {
+		if (authTLSContext.Cert != "" && authTLSContext.Key == "") || (authTLSContext.Cert == "" && authTLSContext.Key != "") {
+			return authTLSContext, errors.New("--registry-auth-tlscontext requires cert=<cert>,key=<key>")
+		}
+	}
+	return authTLSContext, nil
+}
+
+func ParseRegistryAuthTLSContext(registryAuthTLSContext []string) (map[string]*authprovider.AuthTLSConfig, error) {
+	var tlsContexts []authTLSContextEntry
+	for _, c := range registryAuthTLSContext {
+		authTLSContext, err := parseRegistryAuthTLSContextCSV(c)
+		if err != nil {
+			return nil, err
+		}
+		tlsContexts = append(tlsContexts, authTLSContext)
+	}
+
+	authConfigs := make(map[string]*authprovider.AuthTLSConfig)
+	for _, c := range tlsContexts {
+		_, ok := authConfigs[c.Host]
+		if !ok {
+			authConfigs[c.Host] = &authprovider.AuthTLSConfig{}
+		}
+		if c.CA != "" {
+			authConfigs[c.Host].RootCAs = append(authConfigs[c.Host].RootCAs, c.CA)
+		}
+		if c.Cert != "" && c.Key != "" {
+			authConfigs[c.Host].KeyPairs = append(authConfigs[c.Host].KeyPairs, authprovider.TLSKeyPair{
+				Key:         c.Key,
+				Certificate: c.Cert,
+			})
+		}
+	}
+	return authConfigs, nil
+}

--- a/cmd/buildctl/build/registryauthtlscontext_test.go
+++ b/cmd/buildctl/build/registryauthtlscontext_test.go
@@ -1,0 +1,109 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRegistryAuthTLSContext(t *testing.T) {
+	type testCase struct {
+		registryAuthTLSContext []string //--registry-auth-tlscontext
+		expected               map[string]*authprovider.AuthTLSConfig
+		expectedErr            string
+	}
+	testCases := []testCase{
+		{
+			registryAuthTLSContext: []string{
+				"host=tcp://myserver:2376,ca=/home/admin/ca-file,cert=/home/admin/cert-file,key=/home/admin/key-file",
+			},
+			expected: map[string]*authprovider.AuthTLSConfig{
+				"tcp://myserver:2376": {
+					RootCAs: []string{
+						"/home/admin/ca-file",
+					},
+					KeyPairs: []authprovider.TLSKeyPair{
+						{
+							Key:         "/home/admin/key-file",
+							Certificate: "/home/admin/cert-file",
+						},
+					},
+				},
+			},
+		},
+		{
+			registryAuthTLSContext: []string{
+				"host=tcp://myserver:2376,cert=/home/admin/cert-file,key=/home/admin/key-file",
+			},
+			expected: map[string]*authprovider.AuthTLSConfig{
+				"tcp://myserver:2376": {
+					KeyPairs: []authprovider.TLSKeyPair{
+						{
+							Key:         "/home/admin/key-file",
+							Certificate: "/home/admin/cert-file",
+						},
+					},
+				},
+			},
+		},
+		{
+			registryAuthTLSContext: []string{
+				"host=tcp://myserver:2376,ca=/home/admin/ca-file",
+			},
+			expected: map[string]*authprovider.AuthTLSConfig{
+				"tcp://myserver:2376": {
+					RootCAs: []string{
+						"/home/admin/ca-file",
+					},
+				},
+			},
+		},
+		{
+			registryAuthTLSContext: []string{
+				"host=tcp://myserver:2376,ca=/home/admin/ca-file,key=/home/admin/key-file",
+			},
+			expectedErr: "--registry-auth-tlscontext requires cert=<cert>,key=<key>",
+		},
+		{
+			registryAuthTLSContext: []string{
+				"host=tcp://myserver:2376,ca=/home/admin/ca-file,cert=/home/admin/cert-file,key=/home/admin/key-file",
+				"host=https://myserver:2376,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt",
+			},
+			expected: map[string]*authprovider.AuthTLSConfig{
+				"tcp://myserver:2376": {
+					RootCAs: []string{
+						"/home/admin/ca-file",
+					},
+					KeyPairs: []authprovider.TLSKeyPair{
+						{
+							Key:         "/home/admin/key-file",
+							Certificate: "/home/admin/cert-file",
+						},
+					},
+				},
+				"https://myserver:2376": {
+					RootCAs: []string{
+						"/path/to/my/ca.crt",
+					},
+					KeyPairs: []authprovider.TLSKeyPair{
+						{
+							Key:         "/path/to/my/key.crt",
+							Certificate: "/path/to/my/cert.crt",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		im, err := ParseRegistryAuthTLSContext(tc.registryAuthTLSContext)
+		if tc.expectedErr == "" {
+			require.EqualValues(t, tc.expected, im)
+		} else {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErr)
+		}
+	}
+}

--- a/session/auth/authprovider/authconfig.go
+++ b/session/auth/authprovider/authconfig.go
@@ -1,0 +1,11 @@
+package authprovider
+
+type AuthTLSConfig struct {
+	RootCAs  []string
+	KeyPairs []TLSKeyPair
+}
+
+type TLSKeyPair struct {
+	Key         string
+	Certificate string
+}

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -29,8 +29,8 @@ import (
 )
 
 const defaultExpiration = 60
-const dockerIndexConfigfileKey = "https://index.docker.io/v1/"
-const dockerRegistryHost = "registry-1.docker.io"
+const dockerHubConfigfileKey = "https://index.docker.io/v1/"
+const dockerHubRegistryHost = "registry-1.docker.io"
 
 func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
 	return &authProvider{
@@ -186,8 +186,8 @@ func (ap *authProvider) getAuthConfig(host string) (*types.AuthConfig, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
 
-	if host == dockerRegistryHost {
-		host = dockerIndexConfigfileKey
+	if host == dockerHubRegistryHost {
+		host = dockerHubConfigfileKey
 	}
 
 	if _, exists := ap.authConfigCache[host]; !exists {

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -29,6 +29,8 @@ import (
 )
 
 const defaultExpiration = 60
+const dockerIndexConfigfileKey = "https://index.docker.io/v1/"
+const dockerRegistryHost = "registry-1.docker.io"
 
 func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
 	return &authProvider{
@@ -183,10 +185,12 @@ func (ap *authProvider) VerifyTokenAuthority(ctx context.Context, req *auth.Veri
 func (ap *authProvider) getAuthConfig(host string) (*types.AuthConfig, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
+
+	if host == dockerRegistryHost {
+		host = dockerIndexConfigfileKey
+	}
+
 	if _, exists := ap.authConfigCache[host]; !exists {
-		if host == "registry-1.docker.io" {
-			host = "https://index.docker.io/v1/"
-		}
 		ac, err := ap.config.GetAuthConfig(host)
 		if err != nil {
 			return nil, err

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -14,16 +14,16 @@ import (
 func TestFetchTokenCaching(t *testing.T) {
 	cfg := &configfile.ConfigFile{
 		AuthConfigs: map[string]types.AuthConfig{
-			dockerIndexConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
+			dockerHubConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
 		},
 	}
 	p := NewDockerAuthProvider(cfg).(*authProvider)
-	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
 	require.NoError(t, err)
 	assert.Equal(t, "hunter2", res.Token)
 
-	cfg.AuthConfigs[dockerIndexConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
-	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	cfg.AuthConfigs[dockerHubConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
+	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
 	require.NoError(t, err)
 
 	// Verify that we cached the result instead of returning hunter3.

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -1,0 +1,31 @@
+package authprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/buildkit/session/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchTokenCaching(t *testing.T) {
+	cfg := &configfile.ConfigFile{
+		AuthConfigs: map[string]types.AuthConfig{
+			dockerIndexConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
+		},
+	}
+	p := NewDockerAuthProvider(cfg).(*authProvider)
+	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	require.NoError(t, err)
+	assert.Equal(t, "hunter2", res.Token)
+
+	cfg.AuthConfigs[dockerIndexConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
+	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	require.NoError(t, err)
+
+	// Verify that we cached the result instead of returning hunter3.
+	assert.Equal(t, "hunter2", res.Token)
+}

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -17,7 +17,7 @@ func TestFetchTokenCaching(t *testing.T) {
 			dockerHubConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
 		},
 	}
-	p := NewDockerAuthProvider(cfg).(*authProvider)
+	p := NewDockerAuthProvider(cfg, nil).(*authProvider)
 	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
 	require.NoError(t, err)
 	assert.Equal(t, "hunter2", res.Token)


### PR DESCRIPTION
Add configured TLS certificate to trust store when making calls to registry auth.

Backport upstream: https://github.com/moby/buildkit/pull/4211/