### PR TITLE
docs: fix default nydus-compressor in nydus.md

### DIFF
--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -34,7 +34,7 @@ buildctl build ... \
 Available options:
 
 - `nydus-fs-version`: Specify nydus image filesystem version, possible values: `5`, `6`, default `6`;
-- `nydus-compressor`: Specify nydus image compressor, possible values: `none`, `lz4_block`, `zstd`, default `lz4_block`;
+- `nydus-compressor`: Specify nydus image compressor, possible values: `none`, `lz4_block`, `zstd`, default `zstd`;
 - `nydus-chunk-dict-image`: Specify nydus chunk dict image reference for data de-duplication;
 
 ### Known limitations


### PR DESCRIPTION
The value of nydus-compressor has changed in the commit 0e8b1ab0f84a95f488a1b8a68bf615c2676cb1ac, update documentation to reflect changes.